### PR TITLE
Fixes changes to DIDs not reflecting in Active DIDs panel after being archived

### DIFF
--- a/src/pages/Credentials/views/Applications/Applications.tsx
+++ b/src/pages/Credentials/views/Applications/Applications.tsx
@@ -54,7 +54,7 @@ const transformApplications = (applications) => {
         const { application } = vc_application;
         return {
             name: `****-${application.id.slice(-4)}`,
-            id: store.credentials.find(credential => credential.id === application.manifest_id)?.name,
+            id: Object.values(store.credentials).find((credential : { id, name})  => credential.id === application.manifest_id)?.["name"],
             type: "Needs Review"
         }
     })

--- a/src/pages/Credentials/views/CredentialManifests/Details/Details.tsx
+++ b/src/pages/Credentials/views/CredentialManifests/Details/Details.tsx
@@ -135,7 +135,7 @@ const Details: Component<{ credential }> = (props) => {
                         <h2>Requirements</h2>
                     </div>
                     <div class="entry-container panel-body">
-                        {Object.entries(credential_manifest.presentation_definition).map(entry => {
+                        {credential_manifest.presentation_definition && Object.entries(credential_manifest.presentation_definition).map(entry => {
                             return (
                                 <div class="entry-row">
                                     <div class="key-entry">{entry[0]}</div>

--- a/src/utils/setup.tsx
+++ b/src/utils/setup.tsx
@@ -47,6 +47,7 @@ export default setupStore;
 export const hydrateDIDStore = async () => {
     const dids = await SSI.getDIDs();
     if (dids.length) {
+        updateStore("user", {});
         for (const did of dids) {
             const updateValue = {
                 ...store.user,


### PR DESCRIPTION
This PR addresses Issue #19. After archiving a DID, the DID is now immediately removed from the Active DIDs panel as expected.

Additionally, this PR also adds null checks in a couple of places for presentation definitions and credentials.