### PR TITLE
Add submission link fields to submission modal

### DIFF
--- a/src/pages/Credentials/views/Applications/Applications.tsx
+++ b/src/pages/Credentials/views/Applications/Applications.tsx
@@ -9,7 +9,7 @@ const Applications: Component = () => {
         incoming: {
             id: "incoming",
             title: "Incoming",
-            listItems: transformApplications(applications),
+            listItems: transformApplications(store.applications),
             fallback: "You have no new Applications to review, so there's nothing here.",
             buttons: [
                 {


### PR DESCRIPTION
This PR addresses adding additional fields to the Submission Link modal so that a user can enter the appropriate name, purpose, and select their preferred Verifier DID to submit with the request. The sample input has also been reduced to only populate the `constraints` field of the `inputDescriptors`. 