### PR TITLE
Remove statusPurpose from issued credential panel header

### DIFF
--- a/src/pages/Credentials/views/IssuedCredentials/IssuedCredentials.tsx
+++ b/src/pages/Credentials/views/IssuedCredentials/IssuedCredentials.tsx
@@ -150,7 +150,6 @@ const transformCredentials = (credentials, status: "active" | "suspended" | "rev
                     credentialName: manifestName,
                     type: credential.issuanceDate,
                     body: formatCredentialData(credential.credentialSubject), 
-                    statusPurpose: credential.credentialStatus?.statusPurpose,
                     metadata: {
                         id: credential.id,
                         issuerId: credential.issuer,


### PR DESCRIPTION
This PR removes the `statusPurpose` from the issued credential's item panel header.