### PR TITLE
Add fallback for old schema structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ After running `npm run build`, preview the production build of the SSI Console.
 ### `npm run cleanup`
 Stop and remove the SSI Service Docker containers.
 
-### `npm run pull-service`
+### `npm run docker-pull`
 Pull the latest SSI Service Docker container image. Runs `docker pull ghcr.io/tbd54566975/ssi-service:main`. 
 
 ## Project Resources

--- a/src/pages/Credentials/views/CredentialManifests/Details/IssueModal/IssueModal.tsx
+++ b/src/pages/Credentials/views/CredentialManifests/Details/IssueModal/IssueModal.tsx
@@ -243,7 +243,7 @@ export default IssueModal;
 
 export const getSchemaForSubject = (schemaId) => {
     if (store.schemas?.length) {
-        const schema = store.schemas.find(({schema}) => schema["$id"]?.endsWith(`/v1/schemas/${schemaId}`));
+        const schema = store.schemas.find(({schema}) => schema["$id"]?.endsWith(`/v1/schemas/${schemaId}`) || schema["id"]?.endsWith(`/v1/schemas/${schemaId}`));
         const { $id, $schema, description, name, ...properties } = schema.schema;
         return {
             properties,


### PR DESCRIPTION
This PR addresses an issue where some SSI instances still have records of the old schema structure. 