### PR TITLE
Add navigation logic after creating credential or manifest

### DIFF
--- a/src/pages/Admin/Credentials/views/CredentialManifests/Details/IssueModal/IssueModal.tsx
+++ b/src/pages/Admin/Credentials/views/CredentialManifests/Details/IssueModal/IssueModal.tsx
@@ -6,6 +6,8 @@ import { credentialInputJson } from "./samples/mock";
 import SSI from "@/utils/service";
 import { store } from "@/utils/store";
 import { hydrateCredentialsStore } from "@/utils/setup";
+import { useNavigate } from "@solidjs/router";
+import { parseIDFromUrl } from "@/utils/helpers";
 
 
 
@@ -53,6 +55,9 @@ const IssueModal: Component<{ content }> = (props) => {
         return dialog.close();
     }
 
+    const navigate = useNavigate();
+    const [credentialId, setCredentialId] = createSignal();
+
     //actual form calls
     const handleSubmit = async (event) => {
         event.preventDefault();
@@ -69,7 +74,8 @@ const IssueModal: Component<{ content }> = (props) => {
         }
         const request = SSI.putCredential(data);
         const setters = { setIsLoading, setIsSuccess, setIsError };
-        handleRequest(event, request, setters);
+        const res = await handleRequest(event, request, setters);
+        setCredentialId(parseIDFromUrl((await res.json()).id));
     };
 
     const handleInput = (event) => {
@@ -226,7 +232,7 @@ const IssueModal: Component<{ content }> = (props) => {
                                     🎉 Successfully issued credential
                                 </div>
                                 <div class="button-row"> 
-                                    <button class="secondary-button" type="button" onClick={() => { closeModal(); hydrateCredentialsStore() }}>
+                                    <button class="secondary-button" type="button" onClick={() => { closeModal(); hydrateCredentialsStore(); navigate(`/credentials/history/${credentialId()}`)}}>
                                         Done
                                     </button>
                                 </div>

--- a/src/pages/Admin/Credentials/views/CredentialManifests/Modal/Modal.tsx
+++ b/src/pages/Admin/Credentials/views/CredentialManifests/Modal/Modal.tsx
@@ -7,6 +7,7 @@ import SSI from "@/utils/service";
 import { store } from "@/utils/store";
 import { hydrateManifestStore, hydrateSchemaStore } from "@/utils/setup";
 import { getSchemaForSubject } from "../Details/IssueModal/IssueModal";
+import { useNavigate } from "@solidjs/router";
 
 const Modal: Component<{ content }> = (props) => {
     let initialFormValues = { 
@@ -66,6 +67,9 @@ const Modal: Component<{ content }> = (props) => {
         setStep(step() - 1);
     }
 
+    const navigate = useNavigate();
+    const [manifestId, setManifestId] = createSignal();
+
     //actual form calls
     const handleSubmit = async (event) => {
         event.preventDefault();
@@ -117,7 +121,8 @@ const Modal: Component<{ content }> = (props) => {
         // in future we prob also want a step for styles and issuance template, but backlog for now
         const request = SSI.putManifest(credentialPayload);
         const setters = { setIsLoading, setIsSuccess, setIsError };
-        const res = handleRequest(event, request, setters);
+        const res = await handleRequest(event, request, setters);
+        setManifestId((await res.json()).credential_manifest.id);
     };
 
     const handleInput = (event) => {
@@ -426,7 +431,7 @@ const Modal: Component<{ content }> = (props) => {
                                     🎉 Successfully created credential
                                 </div>
                                 <div class="button-row"> 
-                                    <button class="secondary-button" type="button" onClick={() => { closeModal(); hydrateManifestStore()}}>
+                                    <button class="secondary-button" type="button" onClick={() => { closeModal(); hydrateManifestStore(); navigate(`/credentials/${manifestId()}`) }}>
                                         Done
                                     </button>
                                 </div>


### PR DESCRIPTION
This PR addresses #13 to add logic to navigate to detail page after creating a credential or manifest.